### PR TITLE
Reference to add the route label parksmap-backend

### DIFF
--- a/modules/templates.adoc
+++ b/modules/templates.adoc
@@ -228,9 +228,15 @@ OpenShift will now:
 ** Using auto-generated user, password, and database name
 * Configure environment variables for the app to connect to the DB
 * Create the correct services
-* Label the app route with `type=parksmap-backend`
 
 All with one command!
+
+Lastly let's add the label `type=parksmap-backend` to our `mlbparks` route, so that our `parksmap` application can pick up the new mlbparks data.
+
+[source]
+----
+oc label route mlbparks type=parksmap-backend
+----
 
 When the build is complete, visit the parks map. Does it work? Think about how
 this could be used in your environment.  For example, a template could define a


### PR DESCRIPTION
The mlbparks application-template only adds parksmap-backend to the service.  It doesn't add it to the route.  So we'd either have to change the application template or add these instructions.  It'd be cleaner to change the application template, but I'm not sure of the impacts to other mlbparks references.  Please let me know if I did something wrong with trying to get it work without adding this label.  This seems to be the only way to get the mlbparks to show up on parksmap.